### PR TITLE
Fix dependency on Om.

### DIFF
--- a/todomvc/project.clj
+++ b/todomvc/project.clj
@@ -10,7 +10,7 @@
                  [org.clojure/clojurescript "1.7.228"]
                  [com.datomic/datomic-free "0.9.5344"]
                  [bidi "1.25.0"]
-                 [org.omcljs/om "1.0.0-alpha29-SNAPSHOT"]
+                 [org.omcljs/om "1.0.0-alpha30"]
                  [ring/ring "1.4.0"]
                  [com.cognitect/transit-clj "0.8.285"]
                  [com.cognitect/transit-cljs "0.8.237"]


### PR DESCRIPTION
Otherwise I was getting this error:
Could not find artifact org.omcljs:om:jar:1.0.0-alpha29-SNAPSHOT in clojars (https://clojars.org/repo/)
This could be due to a typo in :dependencies or network issues.
If you are behind a proxy, try setting the 'http_proxy' environment variable.